### PR TITLE
timeout is seconds, not milliseconds

### DIFF
--- a/src/main/java/org/jlab/btm/business/service/epics/PVMonitorManager.java
+++ b/src/main/java/org/jlab/btm/business/service/epics/PVMonitorManager.java
@@ -112,7 +112,7 @@ public class PVMonitorManager {
       channels.put(pv, channel);
     }
 
-    context.pendIO(10000);
+    context.pendIO(10);
 
     for (String pv : PV_LIST) {
       CAJChannel channel = channels.get(pv);
@@ -135,7 +135,7 @@ public class PVMonitorManager {
       monitors.put(pv, monitor);
     }
 
-    context.pendIO(10000);
+    context.pendIO(10);
   }
 
   private void stopMonitors() throws CAException {


### PR DESCRIPTION
Fixes #38

In my defense, there are no [comments / javadocs](https://www.javadoc.io/doc/org.epics/jca/latest/gov/aps/jca/Context.html#pendIO(double)) for the method to indicate units. :)   

Fortunately, I did get it right other places, namely epics2web: https://github.com/JeffersonLab/epics2web/blob/652390e80707139b43b71dcaedd37686388469eb/src/main/java/org/jlab/epics2web/epics/ChannelManager.java#L31